### PR TITLE
Allow shared DB class to be defined without logger

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -5,10 +5,13 @@ const co = require('co')
 const url = require('url')
 
 module.exports = function (Sequelize, log) {
+  if (typeof log === 'object') {
+    log.warn('DEPRECATED: Do not pass a logger to five-bells-shared Database constructor. Instead, please pass it via the logging config option.')
+  }
   return class DB extends Sequelize {
     constructor (uri, options) {
       options = _.merge({
-        logging: log.debug,
+        logging: typeof log === 'object' ? log.debug : false,
         omitNull: true
       }, options)
       const dbParts = url.parse(uri)
@@ -23,7 +26,7 @@ module.exports = function (Sequelize, log) {
     }
 
     sync () {
-      log.info('synchronizing database schema')
+      this.options.logging('synchronizing database schema')
       return super.sync()
     }
 


### PR DESCRIPTION
I'm working on the notary, which uses dependency injection to cleanly separate between classes and instantiated objects.

The shared Database class currently depends on a logger instance just to be defined, which is bad. Instead the logger should be passed in via the constructor. Fortunately, a facility for that already exists.