### PR TITLE
Manage key config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const url = require('url')
+const tweetnacl = require('tweetnacl')
 
 /**
  * Config management helper class.
@@ -108,6 +109,37 @@ class Config {
       // When using SQLite in-memory database, default to sync enabled
       this.db.uri === 'sqlite://'
     )
+  }
+
+  /**
+   * Load configuration of this process' keypair.
+   */
+  parseKeyConfig () {
+    this.keys = {}
+    this.keys.ed25519 = {
+      secret: process.env.ED25519_SECRET_KEY,
+      public: process.env.ED25519_PUBLIC_KEY
+    }
+
+    let keyPair
+    if (!this.keys.ed25519.secret) {
+      if (process.env.NODE_ENV === 'production') {
+        throw new Error('No ED25519_SECRET_KEY provided.')
+      }
+      keyPair = tweetnacl.sign.keyPair()
+      this.keys.ed25519.secret = tweetnacl.util.encodeBase64(keyPair.secretKey)
+      this.keys.ed25519.public = tweetnacl.util.encodeBase64(keyPair.publicKey)
+    }
+
+    if (!this.keys.ed25519.public) {
+      if (!keyPair) {
+        keyPair = tweetnacl.sign.keyPair.fromSecretKey(
+          tweetnacl.util.decodeBase64(this.keys.ed25519.secret))
+      }
+      this.keys.ed25519.public =
+        tweetnacl.util.encodeBase64(keyPair.publicKey)
+    }
+
   }
 }
 


### PR DESCRIPTION
Currently, this is [implemented in -ledger](https://github.com/interledger/five-bells-ledger/blob/master/src/services/config.js#L20-L42). But since many Five Bells components will hold keys, it makes sense to move the key config management to -shared.