### PR TITLE
Log db uri

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -22,6 +22,10 @@ module.exports = function (Sequelize, log) {
         options.storage = dbParts.pathname
       }
 
+      if (options.logging) {
+        options.logging('using database ' + uri)
+      }
+
       super(uri, options)
     }
 
@@ -43,7 +47,9 @@ module.exports = function (Sequelize, log) {
     }
 
     sync () {
-      this.options.logging('synchronizing database schema')
+      if (this.options.logging) {
+        this.options.logging('synchronizing database schema')
+      }
       return super.sync()
     }
 


### PR DESCRIPTION
If you're passing in a database URI it's useful to check to ensure it is using the correct one
We might also want to create an option to completely disable the use of sqlite so that it is not use accidentally in production