### PR TITLE
BREAKING: Config#loadConfig returns Immutable.Map config object

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,150 +1,196 @@
 'use strict'
 
+const Immutable = require('immutable')
 const url = require('url')
 const tweetnacl = require('tweetnacl')
 
+function isRunningTests () {
+  return process.argv[0].endsWith('mocha') ||
+    (process.argv.length > 1 && process.argv[0].endsWith('node') &&
+     process.argv[1].endsWith('mocha'))
+}
+
+function useTestConfig () {
+  return !castBool(process.env.UNIT_TEST_OVERRIDE) && isRunningTests()
+}
+
 /**
- * Config management helper class.
+ * Parse a boolean config variable.
  *
- * @example
- * class MyConfig extends Config {
- *   constructor () {
- *     super('example')
- *     this.parseServerConfig()
- *     this.parseDatabaseConfig()
- *   }
- * }
+ * Environment variables are passed in as strings, but this function can turn
+ * values like `undefined`, `''`, `'0'` and `'false'` into `false`.
+ *
+ * If a default value is provided, `undefined` and `''` will return the
+ * default value.
+ *
+ * Values other than `undefined`, `''`, `'1'`, `'0'`, `'true'`, and `'false'` will throw.
+ *
+ * @param {String} value Config value
+ * @param {Boolean} defaultValue Value to be returned for undefined or empty inputs
+ * @param {Boolean} Same config value intelligently cast to bool
  */
-class Config {
-  /**
-   * Constructor.
-   *
-   * @param {String} prefix Prefix to apply to all env variable names. Should be
-   *   in lowercase with dashes as separators. Will automatically be converted
-   *   to uppercase with underscores or other formats as necessary.
-   */
-  constructor (prefix) {
-    this.prefix = prefix || ''
-    this.uppercasePrefix = this.prefix.toUpperCase().replace(/-/g, '_') +
-      (prefix ? '_' : '')
+function castBool (value, defaultValue) {
+  value = value && value.trim()
+  if (value === undefined || value === '') return Boolean(defaultValue)
+  if (value === 'true' || value === '1') return true
+  if (value === 'false' || value === '0') return false
+  throw new Error('castBool unexpected value: ' + value)
+}
+
+/**
+ * Get a config value from the environment.
+ *
+ * Applies the config prefix defined in the constructor.
+ *
+ *
+ * @param {String} prefix prefix
+ * @param {String} name Config key (will be prefixed)
+ * @return {String} Config value or undefined
+ *
+ * getEnv('example', 'my_setting') === process.env.EXAMPLE_MY_SETTING
+ */
+function getEnv (prefix, name) {
+  let envVar
+  if (name && prefix) envVar = `${prefix}_${name}`
+  else if (name && !prefix) envVar = name
+  else if (!name && prefix) envVar = prefix
+  else throw new Error('Invalid environment variable')
+
+  return process.env[envVar.toUpperCase().replace(/-/g, '_')]
+}
+
+/**
+ * Parse the server configuration settings from the environment.
+ */
+function parseServerConfig (prefix) {
+  const secure = castBool(getEnv(prefix, 'PUBLIC_HTTPS'))
+  const bind_ip = getEnv(prefix, 'BIND_IP') || '0.0.0.0'
+
+  let port = parseInt(getEnv(prefix, 'PORT'), 10) || 3000
+  let public_host = getEnv(prefix, 'HOSTNAME') || require('os').hostname()
+  let public_port = parseInt(getEnv(prefix, 'PUBLIC_PORT'), 10) || port
+
+  if (useTestConfig()) {
+    public_host = 'localhost'
+    port = 61337
+    public_port = 80
   }
 
-  /**
-   * Get a config value from the environment.
-   *
-   * Applies the config prefix defined in the constructor.
-   *
-   * @param {String} name Config key (will be prefixed)
-   * @return {String} Config value or undefined
-   *
-   * @example
-   * const config = new Config('example')
-   * config.getEnv('MY_SETTING') === process.env.EXAMPLE_MY_SETTING
-   */
-  getEnv (name) {
-    return process.env[this.uppercasePrefix + name]
-  }
+  // Depends on previously defined config values
+  const isCustomPort = secure
+    ? +public_port !== 443
+    : +public_port !== 80
 
-  /**
-   * Parse a boolean config variable.
-   *
-   * Environment variables are passed in as strings, but this function can turn
-   * values like `undefined`, `''`, `'0'` and `'false'` into `false`.
-   *
-   * If a default value is provided, `undefined` and `''` will return the
-   * default value.
-   *
-   * Values other than `undefined`, `''`, `'1'`, `'0'`, `'true'`, and `'false'` will throw.
-   *
-   * @param {String} value Config value
-   * @param {Boolean} defaultValue Value to be returned for undefined or empty inputs
-   * @param {Boolean} Same config value intelligently cast to bool
-   */
-  static castBool (value, defaultValue) {
-    value = value && value.trim()
-    if (value === undefined || value === '') return Boolean(defaultValue)
-    if (value === 'true' || value === '1') return true
-    if (value === 'false' || value === '0') return false
-    throw new Error('castBool unexpected value: ' + value)
-  }
+  const base_host = public_host + (isCustomPort ? ':' + public_port : '')
+  const base_uri = url.format({
+    protocol: 'http' + (secure ? 's' : ''),
+    host: base_host
+  })
 
-  /**
-   * Populates the configuration with server settings from the environment.
-   */
-  parseServerConfig () {
-    this.server = {}
-    this.server.secure = Config.castBool(this.getEnv('PUBLIC_HTTPS'))
-    this.server.bind_ip = this.getEnv('BIND_IP') || '0.0.0.0'
-    this.server.port = this.getEnv('PORT') || 3000
-    this.server.public_host = this.getEnv('HOSTNAME') || require('os').hostname()
-    this.server.public_port = this.getEnv('PUBLIC_PORT') || this.server.port
-
-    this.updateDerivativeServerConfig()
-  }
-
-  /**
-   * Update server config options that are derivative from other options.
-   */
-  updateDerivativeServerConfig () {
-    // Calculate base_uri
-    const isCustomPort = this.server.secure
-      ? +this.server.public_port !== 443
-      : +this.server.public_port !== 80
-    this.server.base_host = this.server.public_host +
-      (isCustomPort ? ':' + this.server.public_port : '')
-    this.server.base_uri = url.format({
-      protocol: 'http' + (this.server.secure ? 's' : ''),
-      host: this.server.base_host
-    })
-  }
-
-  /**
-   * Populates the configuration with database settings from the environment.
-   */
-  parseDatabaseConfig () {
-    this.db = {}
-
-    // Database URI
-    this.db.uri = this.getEnv('DB_URI')
-
-    // Synchronize schema when the application starts
-    this.db.sync = Config.castBool(
-      this.getEnv('DB_SYNC'),
-      // When using SQLite in-memory database, default to sync enabled
-      this.db.uri === 'sqlite://'
-    )
-  }
-
-  /**
-   * Load configuration of this process' keypair.
-   */
-  parseKeyConfig () {
-    this.keys = {}
-    this.keys.ed25519 = {
-      secret: this.getEnv('ED25519_SECRET_KEY'),
-      public: this.getEnv('ED25519_PUBLIC_KEY')
-    }
-
-    let keyPair
-    if (!this.keys.ed25519.secret) {
-      if (process.env.NODE_ENV === 'production') {
-        throw new Error('No ' + this.uppercasePrefix + 'ED25519_SECRET_KEY provided.')
-      }
-      keyPair = tweetnacl.sign.keyPair()
-      this.keys.ed25519.secret = tweetnacl.util.encodeBase64(keyPair.secretKey)
-      this.keys.ed25519.public = tweetnacl.util.encodeBase64(keyPair.publicKey)
-    }
-
-    if (!this.keys.ed25519.public) {
-      if (!keyPair) {
-        keyPair = tweetnacl.sign.keyPair.fromSecretKey(
-          tweetnacl.util.decodeBase64(this.keys.ed25519.secret))
-      }
-      this.keys.ed25519.public =
-        tweetnacl.util.encodeBase64(keyPair.publicKey)
-    }
-
+  return {
+    secure,
+    bind_ip,
+    port,
+    public_host,
+    public_port,
+    base_host,
+    base_uri
   }
 }
 
-module.exports = Config
+/*
+ * Parse the database configuration settings from the environment.
+ */
+function parseDatabaseConfig (prefix) {
+  // Database URI
+  let uri = getEnv(prefix, 'DB_URI')
+
+  if (useTestConfig()) {
+    // We use a different config parameter for unit tests, because typically one
+    // wouldn't want to use their production or even dev databases for unit tests
+    // and it'd be far to easy to do that accidentally by running npm test.
+    uri = process.env.LEDGER_UNIT_DB_URI || 'sqlite://'
+  }
+
+  // Synchronize schema when the application starts
+  // When using SQLite in-memory database, default to sync enabled
+  const sync = castBool(getEnv(prefix, 'DB_SYNC'), uri === 'sqlite://')
+
+  return {
+    uri,
+    sync
+  }
+}
+
+/**
+ * Parse keypair configuration from the environment
+ */
+function parseKeyConfig (prefix) {
+  const ed25519 = {
+    secret: getEnv(prefix, 'ED25519_SECRET_KEY'),
+    public: getEnv(prefix, 'ED25519_PUBLIC_KEY')
+  }
+
+  let keyPair
+  if (!ed25519.secret) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('No ' + this.uppercasePrefix + 'ED25519_SECRET_KEY provided.')
+    }
+    keyPair = tweetnacl.sign.keyPair()
+    ed25519.secret = tweetnacl.util.encodeBase64(keyPair.secretKey)
+    ed25519.public = tweetnacl.util.encodeBase64(keyPair.publicKey)
+  }
+
+  if (!ed25519.public) {
+    if (!keyPair) {
+      keyPair = tweetnacl.sign.keyPair.fromSecretKey(
+        tweetnacl.util.decodeBase64(ed25519.secret))
+    }
+    ed25519.public =
+      tweetnacl.util.encodeBase64(keyPair.publicKey)
+  }
+
+  return {
+    ed25519
+  }
+}
+
+/**
+ * @param {String} prefix Prefix to apply to all env variable names. Should be
+ *   in lowercase with dashes as separators. Will automatically be converted
+ *   to uppercase with underscores or other formats as necessary.
+ *
+ * @param {Object} [localConfig]
+ * @returns {Immutable.Map} - Immutable Config
+ *
+ * @example
+ *   const config = loadConfig('prefix', localConfig)
+ *   config.toJSON()
+ *   => { foo: {bar: 'baz'} }
+ *
+ *   config.getIn('foo.bar')
+ *   => 'baz'
+ *
+ */
+function loadConfig (prefix, localConfig) {
+  const server = parseServerConfig(prefix, localConfig && localConfig.server)
+  const db = parseDatabaseConfig(prefix, localConfig && localConfig.db)
+  const keys = parseKeyConfig(prefix, localConfig && localConfig.keys)
+
+  const commonConfig = Immutable.fromJS({server, db, keys})
+
+  return commonConfig.merge(localConfig || {})
+}
+
+module.exports = {
+  getEnv,
+  loadConfig,
+  castBool,
+  // For unit tests
+  _private: {
+    parseKeyConfig,
+    parseServerConfig,
+    parseDatabaseConfig
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "NODE_ENV=unit node node_modules/.bin/istanbul test -- _mocha",
+    "test": "istanbul test -- _mocha",
     "jsdoc": "jsdoc -R README.md -c jsdoc.json lib/* ; cp -r docs docs-out"
   },
   "repository": {
@@ -28,6 +28,7 @@
     "canonical-json": "0.0.4",
     "co": "^4.1.0",
     "co-body": "^1.0.0",
+    "immutable": "^3.7.6",
     "lodash": "^3.8.0",
     "mag-colored-output": "^1.0.0",
     "mag-format-message": "^0.1.1",

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -1,19 +1,17 @@
 'use strict'
 
+const _ = require('lodash')
 const chai = require('chai')
 const expect = chai.expect
 const Config = require('../lib/config')
 
-describe('Config', function () {
-  describe('constructor', function () {
-    it('should correctly convert the prefix', function () {
-      const config = new Config('a-long-PrEFiX')
-
-      expect(config.uppercasePrefix).to.equal('A_LONG_PREFIX_')
-    })
+const originalEnv = _.cloneDeep(process.env)
+describe('Config', () => {
+  beforeEach(() => {
+    process.env = _.cloneDeep(originalEnv)
   })
 
-  describe('castBool', function () {
+  describe('castBool()', () => {
     it('should return false for castBool("0")', function () {
       expect(Config.castBool('0')).to.equal(false)
     })
@@ -66,6 +64,225 @@ describe('Config', function () {
 
     it('should return true for castBool("1", false)', function () {
       expect(Config.castBool('1', false)).to.equal(true)
+    })
+  })
+
+  describe('getEnv()', () => {
+    it('returns an environment variable defined with a prefix', () => {
+      process.env['PREFIX_FOO'] = 'bar'
+      expect(Config.getEnv('prefix', 'foo')).to.equal('bar')
+    })
+
+    it('returns an env variable defined without prefix', () => {
+      process.env['FOO'] = 'bar'
+      expect(Config.getEnv('FOO')).to.equal('bar')
+      expect(Config.getEnv(undefined, 'FOO')).to.equal('bar')
+    })
+
+    it('throws an error on invalid arguments', () => {
+      expect(() => Config.getEnv()).to.throw()
+      expect(() => Config.getEnv('')).to.throw()
+      expect(() => Config.getEnv('', '')).to.throw()
+      expect(() => Config.getEnv(undefined, undefined)).to.throw()
+    })
+  })
+
+  describe('parseServerConfig', () => {
+    const testDefaults = {
+      base_host: 'localhost',
+      base_uri: 'http://localhost',
+      bind_ip: '0.0.0.0',
+      port: 61337,
+      public_host: 'localhost',
+      public_port: 80,
+      secure: false
+    }
+
+    const hostname = require('os').hostname()
+    const defaults = {
+      base_host: `${hostname}:3000`,
+      base_uri: `http://${hostname}:3000`,
+      bind_ip: '0.0.0.0',
+      public_host: hostname,
+      public_port: 3000,
+      secure: false,
+      port: 3000
+    }
+
+    it('test -- returns default server config when no server env vars set', () => {
+      expect(Config._private.parseServerConfig()).to.deep.equal(testDefaults)
+    })
+
+    it('returns default server config when no server env vars set', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      expect(Config._private.parseServerConfig()).to.deep.equal(defaults)
+    })
+
+    it('PUBLIC_HTTPS=true', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      process.env.PUBLIC_HTTPS = 'true'
+      const server = _.defaults({
+        base_uri: `https://${hostname}:3000`,
+        secure: true
+      }, defaults)
+      expect(Config._private.parseServerConfig()).to.deep.equal(server)
+    })
+
+    it('BIND_IP=10.10.10.10', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      process.env.BIND_IP = '10.10.10.10'
+      const server = _.defaults({
+        bind_ip: '10.10.10.10'
+      }, defaults)
+
+      expect(Config._private.parseServerConfig()).to.deep.equal(server)
+    })
+
+    it('PUBLIC_PORT=5000', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      process.env.PUBLIC_PORT = '5000'
+      const server = _.defaults({
+        base_host: `${hostname}:5000`,
+        base_uri: `http://${hostname}:5000`,
+        public_host: hostname,
+        public_port: 5000,
+        secure: false,
+        port: 3000
+      }, defaults)
+      expect(Config._private.parseServerConfig()).to.deep.equal(server)
+    })
+
+    it('PORT=5000', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      process.env.PORT = '5000'
+      const server = _.defaults({
+        base_host: `${hostname}:5000`,
+        base_uri: `http://${hostname}:5000`,
+        public_host: hostname,
+        public_port: 5000,
+        secure: false,
+        port: 5000
+      }, defaults)
+      expect(Config._private.parseServerConfig()).to.deep.equal(server)
+    })
+  })
+
+  describe('parseKeyConfig', () => {
+    it('test env -- ed25519', () => {
+      const keyConfig = Config._private.parseKeyConfig()
+      expect(keyConfig).to.include.keys('ed25519')
+      expect(keyConfig.ed25519).to.include.keys('secret', 'public')
+    })
+
+    it('ed25519', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      const keyConfig = Config._private.parseKeyConfig()
+      expect(keyConfig).to.include.keys('ed25519')
+      expect(keyConfig.ed25519).to.include.keys('secret', 'public')
+    })
+
+    it('ED25519_SECRET_KEY', () => {
+      const secret = 'WvWye3P79SXVGWJT8E4NhsGeKgJZlxhMyXDh7cRcbHsEqvDmg2dhC8EWdAAwTf6B8hzzdI/dq7WZXyqEobN9rw=='
+      process.env.ED25519_SECRET_KEY = secret
+      const keyConfig = Config._private.parseKeyConfig()
+      expect(keyConfig).to.include.keys('ed25519')
+      expect(keyConfig.ed25519).to.include.keys('secret', 'public')
+      expect(keyConfig.ed25519.secret).to.equal(secret)
+    })
+  })
+
+  describe('parseDatabaseConfig', () => {
+    const testDefaults = {
+      sync: true,
+      uri: 'sqlite://'
+    }
+
+    const defaults = {
+      sync: false,
+      uri: undefined
+    }
+
+    it('test -- returns default db config when no server env vars set', () => {
+      expect(Config._private.parseDatabaseConfig()).to.deep.equal(testDefaults)
+    })
+
+    it('test -- returns default db config when no server env vars set', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      expect(Config._private.parseDatabaseConfig()).to.deep.equal(defaults)
+    })
+
+    it('DB_SYNC=true', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      process.env.DB_SYNC = 'true'
+      const db = _.defaults({
+        sync: true
+      }, defaults)
+      expect(Config._private.parseDatabaseConfig()).to.deep.equal(db)
+    })
+
+    it('DB_URI=localhost:5000', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      process.env.DB_URI = 'localhost:5000'
+      const db = _.defaults({
+        uri: 'localhost:5000'
+      }, defaults)
+      expect(Config._private.parseDatabaseConfig()).to.deep.equal(db)
+    })
+  })
+
+  describe('loadConfig()', () => {
+    it('returns an Immutable config object', () => {
+      const _config = Config.loadConfig()
+
+      // _config.toJS()
+      // db: {
+      //   sync: true,
+      //   uri: 'sqlite://'
+      // },
+      // keys: {
+      //   ed25519: {
+      //     public: 'QxV0xwSiFb1jGzk+K3/s45y2oKSB2b0LQo50QiU/d28=',
+      //     secret: '9Q8W9m9k2dBMFFM6w+0evSR8a+jSApL6uK+ekz96fKBDFXTHBKIVvWMbOT4rf+zjnLagpIHZvQtCjnRCJT93bw=='
+      //   }
+      // },
+      // server: {
+      //   base_host: 'localhost',
+      //   base_uri: 'http://localhost',
+      //   bind_ip: '0.0.0.0',
+      //   port: 61337,
+      //   public_host: 'localhost',
+      //   public_port: 80,
+      //   secure: false
+      // }
+
+      expect(_config.toJSON()).to.include.keys('db', 'keys', 'server')
+      expect(_config.get('db').toJS()).to.deep.equal({
+        sync: true,
+        uri: 'sqlite://'
+      })
+
+      expect(_config.getIn(['db', 'sync'])).to.equal(true)
+      expect(_config.getIn(['db', 'uri'])).to.equal('sqlite://')
+
+      expect(_config.get('server').toJS()).to.deep.equal({
+        base_host: 'localhost',
+        base_uri: 'http://localhost',
+        bind_ip: '0.0.0.0',
+        port: 61337,
+        public_host: 'localhost',
+        public_port: 80,
+        secure: false
+      })
+
+      expect(_config.get('keys').toJS()).to.include.keys('ed25519')
+    })
+
+    describe('with a localConfig', () => {
+      it('extends common config with localConfig object', () => {
+        const localConfig = {foo: {bar: {test: 'test'}}}
+        const _config = Config.loadConfig('prefix', localConfig)
+        expect(_config.getIn(['foo', 'bar']).toJS()).to.deep.equal({test: 'test'})
+      })
     })
   })
 })


### PR DESCRIPTION
config = require('lib/config').loadConfig('prefix') // prefix is the env var
prefix
config.getIn(['db', 'uri']) // returns config value at a given path
config.toJS() //returns the object representation of the config