### PR TITLE
Default to SERIALIZABLE isolation level and retry failed db transactions

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -3,12 +3,16 @@
 const _ = require('lodash')
 const co = require('co')
 const url = require('url')
+const retry = require('retry-as-promised')
+
+const DEFAULT_MAX_TRANSACTION_RETRIES = 5
 
 module.exports = function (Sequelize, log) {
   if (typeof log === 'object') {
     log.warn('DEPRECATED: Do not pass a logger to five-bells-shared Database constructor. Instead, please pass it via the logging config option.')
   }
   return class DB extends Sequelize {
+    // options.maxTransactionRetries is the number of times to retry transactions that fail due to serialization / transaction isolation errors
     constructor (uri, options) {
       options = _.merge({
         logging: typeof log === 'object' ? log.debug : false,
@@ -29,6 +33,8 @@ module.exports = function (Sequelize, log) {
       }
 
       super(uri, options)
+
+      this.maxTransactionRetries = options.maxTransactionRetries || DEFAULT_MAX_TRANSACTION_RETRIES
     }
 
     * init () {
@@ -62,14 +68,25 @@ module.exports = function (Sequelize, log) {
       }
 
       // Turn the generator into a promise, then call upstream transaction().
-      return super.transaction(function (tr) {
-        const generator = transactionFn.call(this, tr)
-        if (typeof generator === 'object' &&
-          typeof generator.next === 'function') {
-          return co(generator)
-        }
+      // Transactions will be retried if they fail with an error due to serialization / transaction isolation
+      return retry(() => {
+        return super.transaction((tr) => {
+          const generator = transactionFn.call(this, tr)
+          if (typeof generator === 'object' &&
+            typeof generator.next === 'function') {
+            return co(generator)
+          }
 
-        return generator
+          return generator
+        })
+      }, {
+        max: this.maxTransactionRetries,
+        match: [
+          'could not serialize access due to concurrent update',
+          'could not serialize access due to read/write dependencies among transactions'
+        ],
+        backoffBase: 100,
+        backoffExponent: 1.1
       })
     }
   }

--- a/lib/db.js
+++ b/lib/db.js
@@ -12,7 +12,9 @@ module.exports = function (Sequelize, log) {
     constructor (uri, options) {
       options = _.merge({
         logging: typeof log === 'object' ? log.debug : false,
-        omitNull: true
+        omitNull: true,
+        // All transactions should be done with isolation level SERIALIZABLE
+        isolationLevel: Sequelize.Transaction.ISOLATION_LEVELS.SERIALIZABLE
       }, options)
       const dbParts = url.parse(uri)
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mag-format-message": "^0.1.1",
     "passport-strategy": "^1.0.0",
     "path-to-regexp": "^1.2.0",
+    "retry-as-promised": "^2.0.1",
     "through2": "^0.6.3",
     "tv4": "^1.2.7",
     "tv4-formats": "^1.0.1",


### PR DESCRIPTION
Since we're dealing with financial applications, we should be using the most conservative [transaction isolation level](https://en.wikipedia.org/wiki/Isolation_(database_systems)#Isolation_levels): `SERIALIZABLE`.

Also, the ledger was running into concurrent update issues when processing multiple transfers simultaneously (see https://github.com/interledger/five-bells-ledger/issues/135 and https://github.com/interledger/five-bells-shared/issues/64). The database was failing -- as it should -- when multiple transactions were attempted concurrently. However, the ledger was responding to the client with `HTTP 500` errors instead of simply retrying the failed database transactions. This adds retry logic for the errors `'could not serialize access due to concurrent update'` and `'could not serialize access due to read/write dependencies among transactions'`.