### PR TITLE
Add authentication configuration

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -3,6 +3,7 @@
 const Immutable = require('immutable')
 const url = require('url')
 const tweetnacl = require('tweetnacl')
+const _ = require('lodash')
 
 function isRunningTests () {
   return process.argv[0].endsWith('mocha') ||
@@ -12,6 +13,14 @@ function isRunningTests () {
 
 function useTestConfig () {
   return !castBool(process.env.UNIT_TEST_OVERRIDE) && isRunningTests()
+}
+
+function removeUndefined (obj) {
+  return _.omit(obj, _.isUndefined)
+}
+
+function removeEmpty (obj) {
+  return _.omit(obj, _.isEmpty)
 }
 
 /**
@@ -58,6 +67,7 @@ function getEnv (prefix, name) {
 
   return process.env[envVar.toUpperCase().replace(/-/g, '_')]
 }
+
 /**
  * Parse the server configuration settings from the environment.
  */
@@ -97,6 +107,15 @@ function parseServerConfig (prefix) {
   }
 }
 
+function parseSSLConfig (prefix) {
+  const key = getEnv(prefix, 'SSL_KEY')
+  const cert = getEnv(prefix, 'SSL_CERTIFICATE')
+  const crl = getEnv(prefix, 'SSL_CRL')
+  const ca = getEnv(prefix, 'SSL_CA')
+
+  return removeUndefined({key, cert, crl, ca})
+}
+
 /*
  * Parse the database configuration settings from the environment.
  */
@@ -115,10 +134,10 @@ function parseDatabaseConfig (prefix) {
   // When using SQLite in-memory database, default to sync enabled
   const sync = castBool(getEnv(prefix, 'DB_SYNC'), uri === 'sqlite://')
 
-  return {
+  return removeUndefined({
     uri,
     sync
-  }
+  })
 }
 
 /**
@@ -154,6 +173,31 @@ function parseKeyConfig (prefix) {
   }
 }
 
+function parseAuthConfig (prefix) {
+  return {
+    basic_enabled: castBool(getEnv(prefix, 'AUTH_BASIC_ENABLED'), true),
+    http_signature_enabled: castBool(getEnv(prefix, 'AUTH_HTTP_SIGNATURE_ENABLED'), true),
+    client_certificates_enabled: castBool(getEnv(prefix, 'AUTH_CLIENT_CERT_ENABLED'), false)
+  }
+}
+
+function validateEnvConfig (prefix) {
+  const _prefix = prefix ? prefix + '_' : ''
+
+  if (_.get(process.env, `${_prefix}AUTH_CLIENT_CERT_ENABLED`) &&
+      !_.get(process.env, `${_prefix}SSL_KEY`)) {
+    throw new Error(
+        `${_prefix}SSL_KEY required for ${_prefix}AUTH_CLIENT_CERT_ENABLED`)
+  }
+
+  if (castBool(_.get(process.env, `${_prefix}PUBLIC_HTTPS`)) &&
+      (!_.get(process.env, `${_prefix}SSL_KEY`) ||
+      !_.get(process.env, `${_prefix}SSL_CERTIFICATE`))) {
+    throw new Error(
+        `Missing ${_prefix}SSL_KEY or ${_prefix}SSL_CERTIFICATE`)
+  }
+}
+
 /**
  * @param {String} prefix Prefix to apply to all env variable names. Should be
  *   in lowercase with dashes as separators. Will automatically be converted
@@ -164,32 +208,33 @@ function parseKeyConfig (prefix) {
  *
  * @example
  *   const config = loadConfig('prefix', localConfig)
- *   config.toJSON()
+ *   config.toJS()
  *   => { foo: {bar: 'baz'} }
  *
- *   config.getIn('foo.bar')
+ *   config.getIn(['foo', 'bar'])
  *   => 'baz'
+ *
+ *   config.get('foo').toJS()
+ *   => {bar: 'baz'}
  *
  */
 function loadConfig (prefix, localConfig) {
-  const server = parseServerConfig(prefix, localConfig && localConfig.server)
-  const db = parseDatabaseConfig(prefix, localConfig && localConfig.db)
-  const keys = parseKeyConfig(prefix, localConfig && localConfig.keys)
+  validateEnvConfig(prefix)
+  const server = parseServerConfig(prefix)
+  const db = parseDatabaseConfig(prefix)
+  const keys = parseKeyConfig(prefix)
+  const auth = parseAuthConfig(prefix)
+  const ssl = parseSSLConfig(prefix)
 
-  const commonConfig = Immutable.fromJS({server, db, keys})
+  const commonConfig = Immutable.fromJS(removeEmpty({server, db, keys, auth, ssl}))
+  const completeConfig = commonConfig.mergeDeep(localConfig || {})
 
-  return commonConfig.mergeDeep(localConfig || {})
+  return completeConfig
 }
 
 module.exports = {
   getEnv,
   loadConfig,
-  castBool,
-  // For unit tests
-  _private: {
-    parseKeyConfig,
-    parseServerConfig,
-    parseDatabaseConfig
-  }
+  castBool
 }
 


### PR DESCRIPTION
Configuration for enabling client certificate authentication:

Example,
```
LEDGER_AUTH_CLIENT_CERT_ENABLED (default: false, requires PUBLIC_HTTPS=true)
CONNECTOR_SSL_KEY (Server wide private key. Requires CERTIFICATE and PUBLIC_HTTPS=true)
CONNECTOR_SSL_CERTIFICATE (Server wide certificate Requires KEY. Requires PUBLIC_HTTPS=true)
CONNECTOR_SSL_CRL (Optional. Certificate Revokation List requires PUBLIC_HTTPS=true and SSL_{KEY|CERTIFICATE})
CONNECTOR_SSL_CA (Optional. Required if Certificate Authority of clients is not part of system CAs. Requires PUBLIC_HTTPS=true and SSL_{KEY|CERTIFICATE})
```

Additional tests

TODO:
Validation for all environment configuration variables