### PR TITLE
Allow public path prefix

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -23,6 +23,10 @@ function removeEmpty (obj) {
   return _.omit(obj, _.isEmpty)
 }
 
+function ensureLeadingSlash (path) {
+  return path.length && path[0] !== '/' ? '/' + path : path
+}
+
 /**
  * Parse a boolean config variable.
  *
@@ -78,12 +82,7 @@ function parseServerConfig (prefix) {
   let port = parseInt(getEnv(prefix, 'PORT'), 10) || 3000
   let public_host = getEnv(prefix, 'HOSTNAME') || require('os').hostname()
   let public_port = parseInt(getEnv(prefix, 'PUBLIC_PORT'), 10) || port
-  let public_path = getEnv(prefix, 'PUBLIC_PATH') || ''
-
-  // Ensure path starts with a slash
-  if (public_path.length && public_path[0] !== '/') {
-    public_path = '/' + public_path
-  }
+  const public_path = ensureLeadingSlash(getEnv(prefix, 'PUBLIC_PATH') || '')
 
   if (useTestConfig()) {
     public_host = 'localhost'

--- a/lib/config.js
+++ b/lib/config.js
@@ -152,7 +152,8 @@ function parseKeyConfig (prefix) {
   let keyPair
   if (!ed25519.secret) {
     if (process.env.NODE_ENV === 'production') {
-      throw new Error('No ' + this.uppercasePrefix + 'ED25519_SECRET_KEY provided.')
+      throw new Error('No ' + (prefix ? prefix.toUpperCase() + '_' : '') +
+        'ED25519_SECRET_KEY provided.')
     }
     keyPair = tweetnacl.sign.keyPair()
     ed25519.secret = tweetnacl.util.encodeBase64(keyPair.secretKey)
@@ -234,4 +235,3 @@ module.exports = {
   loadConfig,
   castBool
 }
-

--- a/lib/config.js
+++ b/lib/config.js
@@ -78,6 +78,12 @@ function parseServerConfig (prefix) {
   let port = parseInt(getEnv(prefix, 'PORT'), 10) || 3000
   let public_host = getEnv(prefix, 'HOSTNAME') || require('os').hostname()
   let public_port = parseInt(getEnv(prefix, 'PUBLIC_PORT'), 10) || port
+  let public_path = getEnv(prefix, 'PUBLIC_PATH') || ''
+
+  // Ensure path starts with a slash
+  if (public_path.length && public_path[0] !== '/') {
+    public_path = '/' + public_path
+  }
 
   if (useTestConfig()) {
     public_host = 'localhost'
@@ -93,7 +99,8 @@ function parseServerConfig (prefix) {
   const base_host = public_host + (isCustomPort ? ':' + public_port : '')
   const base_uri = url.format({
     protocol: 'http' + (secure ? 's' : ''),
-    host: base_host
+    host: base_host,
+    pathname: public_path
   })
 
   return {
@@ -102,6 +109,7 @@ function parseServerConfig (prefix) {
     port,
     public_host,
     public_port,
+    public_path,
     base_host,
     base_uri
   }

--- a/lib/notificationScheduler.js
+++ b/lib/notificationScheduler.js
@@ -4,11 +4,18 @@ const defer = require('co-defer')
 const MAX_32INT = 2147483647
 
 /**
+ * Callback to process a notification.
+ * @callback processNotification
+ * @param {Object} notification
+ * @return {Promise}
+ */
+
+/**
  * @param {Object} options
  * @param {Class} options.Notification
  * @param {Object} options.knex
  * @param {Logger} options.log
- * @param {function(notification) -> Promise} options.processNotification
+ * @param {processNotification} options.processNotification
  */
 function NotificationScheduler (options) {
   this.Notification = options.Notification

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "istanbul test -- _mocha",
-    "jsdoc": "jsdoc -R README.md -c jsdoc.json lib/* ; cp -r docs docs-out"
+    "jsdoc": "jsdoc -R README.md -c jsdoc.json lib/* && cp -r docs docs-out"
   },
   "repository": {
     "type": "git",

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -96,6 +96,7 @@ describe('Config', () => {
       port: 61337,
       public_host: 'localhost',
       public_port: 80,
+      public_path: '',
       secure: false
     }
 
@@ -106,6 +107,7 @@ describe('Config', () => {
       bind_ip: '0.0.0.0',
       public_host: hostname,
       public_port: 3000,
+      public_path: '',
       secure: false,
       port: 3000
     }
@@ -175,6 +177,36 @@ describe('Config', () => {
         port: 5000
       }, defaults)
 
+      const _config = Config.loadConfig()
+      expect(_config.get('server').toJS()).to.deep.equal(server)
+    })
+
+    it('PUBLIC_PATH=', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      process.env.PUBLIC_PATH = ''
+      const server = defaults
+      const _config = Config.loadConfig()
+      expect(_config.get('server').toJS()).to.deep.equal(server)
+    })
+
+    it('PUBLIC_PATH=/example', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      process.env.PUBLIC_PATH = '/example'
+      const server = _.defaults({
+        base_uri: `http://${hostname}:3000/example`,
+        public_path: '/example'
+      }, defaults)
+      const _config = Config.loadConfig()
+      expect(_config.get('server').toJS()).to.deep.equal(server)
+    })
+
+    it('PUBLIC_PATH=example', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      process.env.PUBLIC_PATH = 'example'
+      const server = _.defaults({
+        base_uri: `http://${hostname}:3000/example`,
+        public_path: '/example'
+      }, defaults)
       const _config = Config.loadConfig()
       expect(_config.get('server').toJS()).to.deep.equal(server)
     })
@@ -384,6 +416,7 @@ describe('Config', () => {
         port: 61337,
         public_host: 'localhost',
         public_port: 80,
+        public_path: '',
         secure: false
       })
 


### PR DESCRIPTION
The configuration already allows the server to operate behind an HTTP reverse proxy, however, it does not allow the proxy to use a path prefix. With this patch the server can operate at a sub-path behind a proxy.

For example, you may be running a ledger in AWS at `http://10.0.0.1:3000`, but it actually exposed via a front proxy at `https://example.com/ledger`. With this patch you can accomplish this by passing `LEDGER_PUBLIC_PATH=/ledger`.

This PR also fixes some very minor issues:

* Crash while generating error message that a server was run in production without a secret key
* JSDoc was broken and CI wasn't set up correct to detect that