### PR TITLE
Fix: PUBLIC_HTTPS option should not affect server

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -76,10 +76,11 @@ function getEnv (prefix, name) {
  * Parse the server configuration settings from the environment.
  */
 function parseServerConfig (prefix) {
-  const secure = castBool(getEnv(prefix, 'PUBLIC_HTTPS'))
+  const secure = castBool(getEnv(prefix, 'USE_HTTPS'))
   const bind_ip = getEnv(prefix, 'BIND_IP') || '0.0.0.0'
 
   let port = parseInt(getEnv(prefix, 'PORT'), 10) || 3000
+  const public_secure = castBool(getEnv(prefix, 'PUBLIC_HTTPS'), secure)
   let public_host = getEnv(prefix, 'HOSTNAME') || require('os').hostname()
   let public_port = parseInt(getEnv(prefix, 'PUBLIC_PORT'), 10) || port
   const public_path = ensureLeadingSlash(getEnv(prefix, 'PUBLIC_PATH') || '')
@@ -91,13 +92,13 @@ function parseServerConfig (prefix) {
   }
 
   // Depends on previously defined config values
-  const isCustomPort = secure
+  const isCustomPort = public_secure
     ? +public_port !== 443
     : +public_port !== 80
 
   const base_host = public_host + (isCustomPort ? ':' + public_port : '')
   const base_uri = url.format({
-    protocol: 'http' + (secure ? 's' : ''),
+    protocol: 'http' + (public_secure ? 's' : ''),
     host: base_host,
     pathname: public_path
   })
@@ -106,6 +107,7 @@ function parseServerConfig (prefix) {
     secure,
     bind_ip,
     port,
+    public_secure,
     public_host,
     public_port,
     public_path,
@@ -190,7 +192,7 @@ function parseAuthConfig (prefix) {
 }
 
 function validateEnvConfig (prefix) {
-  const secureOrClientCertEnabled = castBool(getEnv(prefix, `PUBLIC_HTTPS`)) ||
+  const secureOrClientCertEnabled = castBool(getEnv(prefix, `USE_HTTPS`)) ||
     getEnv(prefix, `AUTH_CLIENT_CERT_ENABLED`)
 
   const missingKeyOrCert = !getEnv(prefix, `TLS_KEY`) ||

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -94,6 +94,7 @@ describe('Config', () => {
       base_uri: 'http://localhost',
       bind_ip: '0.0.0.0',
       port: 61337,
+      public_secure: false,
       public_host: 'localhost',
       public_port: 80,
       public_path: '',
@@ -105,6 +106,7 @@ describe('Config', () => {
       base_host: `${hostname}:3000`,
       base_uri: `http://${hostname}:3000`,
       bind_ip: '0.0.0.0',
+      public_secure: false,
       public_host: hostname,
       public_port: 3000,
       public_path: '',
@@ -123,6 +125,22 @@ describe('Config', () => {
       expect(_config.get('server').toJS()).to.deep.equal(defaults)
     })
 
+    it('HTTPS=true', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      process.env.USE_HTTPS = 'true'
+      // HTTPS requires TLS configuration to be set
+      process.env.TLS_KEY = '/foo/key'
+      process.env.TLS_CERTIFICATE = '/foo/crt'
+      const server = _.defaults({
+        base_uri: `https://${hostname}:3000`,
+        public_secure: true,
+        secure: true
+      }, defaults)
+
+      const _config = Config.loadConfig()
+      expect(_config.get('server').toJS()).to.deep.equal(server)
+    })
+
     it('PUBLIC_HTTPS=true', () => {
       process.env.UNIT_TEST_OVERRIDE = 'true'
       process.env.PUBLIC_HTTPS = 'true'
@@ -131,7 +149,25 @@ describe('Config', () => {
       process.env.TLS_CERTIFICATE = '/foo/crt'
       const server = _.defaults({
         base_uri: `https://${hostname}:3000`,
-        secure: true
+        public_secure: true
+      }, defaults)
+
+      const _config = Config.loadConfig()
+      expect(_config.get('server').toJS()).to.deep.equal(server)
+    })
+
+    it('PUBLIC_HTTPS=true PUBLIC_PORT=443', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      process.env.PUBLIC_HTTPS = 'true'
+      process.env.PUBLIC_PORT = '443'
+      // HTTPS requires TLS configuration to be set
+      process.env.TLS_KEY = '/foo/key'
+      process.env.TLS_CERTIFICATE = '/foo/crt'
+      const server = _.defaults({
+        base_host: `${hostname}`,
+        base_uri: `https://${hostname}`,
+        public_secure: true,
+        public_port: 443
       }, defaults)
 
       const _config = Config.loadConfig()
@@ -343,7 +379,7 @@ describe('Config', () => {
   describe('parseTLSConfig', () => {
     beforeEach(() => {
       process.env.DB_URI = 'localhost:5000'
-      process.env.PUBLIC_HTTPS = 'true'
+      process.env.USE_HTTPS = 'true'
     })
 
     it('TLS_KEY, TLS_CERTIFICATE, TLS_CRL, TLS_CA', () => {
@@ -414,6 +450,7 @@ describe('Config', () => {
         base_uri: 'http://localhost',
         bind_ip: '0.0.0.0',
         port: 61337,
+        public_secure: false,
         public_host: 'localhost',
         public_port: 80,
         public_path: '',


### PR DESCRIPTION
The `PUBLIC_*` options are intended to configure the public-facing URL of the server. They should not affect anything else. Their purpose is to allow the user to configure the ledger's public URI if it is located behind a reverse proxy or load balancer.

This splits `PUBLIC_HTTPS` into two options `USE_HTTPS` and `PUBLIC_HTTPS`:

* `USE_HTTPS` - Enable HTTPS server (defaults to `false`)
* `PUBLIC_HTTPS` - Whether public URLs are HTTPS URLs (defaults to value of `USE_HTTPS`)

This PR is technically a breaking change because it changes the behavior of a config option. However I'm not aware of anyone using HTTPS yet, so nobody should be affected. The upgrade procedure is to change your config from `XXX_PUBLIC_HTTPS=true` to `XXX_USE_HTTPS=true` if you want the server to listen with TLS enabled.

cc/ @lumberj 