### PR TITLE
Update to 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "five-bells-shared",
-  "version": "9.3.0",
+  "version": "10.0.0",
   "description": "Shared components for Five Bells projects.",
   "keywords": [
     "interledger",


### PR DESCRIPTION
Includes:

799621d Fix crash when no secret key is provided in prod.
9082d39 Allow configuration of a public path prefix.
69a0609 Fix: Fail CI when JSDoc fails
6d27922 Fix failing JSDoc generation
dc4675e Turn ensureLeadingSlash into a function
0fcb989 BREAKING: Read TLS crt, crl, key, and ca into memory