### PR TITLE
Fix failing TLS test cases

### DIFF
--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -126,12 +126,12 @@ describe('Config', () => {
       expect(_config.get('server').toJS()).to.deep.equal(defaults)
     })
 
-    it('HTTPS=true', () => {
+    it('USE_HTTPS=true', () => {
       process.env.UNIT_TEST_OVERRIDE = 'true'
       process.env.USE_HTTPS = 'true'
       // HTTPS requires TLS configuration to be set
-      process.env.TLS_KEY = '/foo/key'
-      process.env.TLS_CERTIFICATE = '/foo/crt'
+      process.env.TLS_KEY = 'test/data/key'
+      process.env.TLS_CERTIFICATE = 'test/data/crt'
       const server = _.defaults({
         base_uri: `https://${hostname}:3000`,
         public_secure: true,
@@ -145,9 +145,6 @@ describe('Config', () => {
     it('PUBLIC_HTTPS=true', () => {
       process.env.UNIT_TEST_OVERRIDE = 'true'
       process.env.PUBLIC_HTTPS = 'true'
-      // HTTPS requires TLS configuration to be set
-      process.env.TLS_KEY = 'test/data/key'
-      process.env.TLS_CERTIFICATE = 'test/data/crt'
       const server = _.defaults({
         base_uri: `https://${hostname}:3000`,
         public_secure: true
@@ -161,9 +158,6 @@ describe('Config', () => {
       process.env.UNIT_TEST_OVERRIDE = 'true'
       process.env.PUBLIC_HTTPS = 'true'
       process.env.PUBLIC_PORT = '443'
-      // HTTPS requires TLS configuration to be set
-      process.env.TLS_KEY = '/foo/key'
-      process.env.TLS_CERTIFICATE = '/foo/crt'
       const server = _.defaults({
         base_host: `${hostname}`,
         base_uri: `https://${hostname}`,


### PR DESCRIPTION
Merging #87 broke the tests due to a faulty merge. (Github thought it could merge it cleanly, but ended up merging it incorrectly.)

This PR fixes the failing tests.