### PR TITLE
FIX: Update to lodash@4

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,11 +16,11 @@ function useTestConfig () {
 }
 
 function removeUndefined (obj) {
-  return _.omit(obj, _.isUndefined)
+  return _.omitBy(obj, _.isUndefined)
 }
 
 function removeEmpty (obj) {
-  return _.omit(obj, _.isEmpty)
+  return _.omitBy(obj, _.isEmpty)
 }
 
 function ensureLeadingSlash (path) {
@@ -258,7 +258,7 @@ configProto.get = function get (propertyPath, defaultValue) {
   return _.get(this, propertyPath, defaultValue)
 }
 configProto.getIn = function getIn (propertyList, defaultValue) {
-  return _.get(this, propertyList.join('.'), defaultValue)
+  return _.get(this, propertyList, defaultValue)
 }
 
 /**

--- a/lib/model-mixin.js
+++ b/lib/model-mixin.js
@@ -25,7 +25,7 @@ const defaultOptions = exports.defaultOptions = {
       }
     },
     applyFilter: _.curry(function (filter, data0) {
-      let data = _.cloneDeep(data0)
+      let data = _.assign({}, _.cloneDeep(data0))
 
       data = filter(data, this)
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -119,7 +119,7 @@ class Model {
    * @return {Object} Plain representation of model
    */
   getData () {
-    return _.cloneDeep(this)
+    return _.assign({}, _.cloneDeep(this))
   }
 
   /**
@@ -134,7 +134,7 @@ class Model {
   }
 
   _applyFilter (filter, data0) {
-    let data = _.cloneDeep(data0)
+    let data = _.assign({}, _.cloneDeep(data0))
 
     data = filter(data, this)
 

--- a/lib/uri-manager.js
+++ b/lib/uri-manager.js
@@ -36,7 +36,7 @@ class UriManager {
   addResource (type, path) {
     const keys = []
     const re = pathToRegexp(path, keys)
-    const keyNames = _.pluck(keys, 'name')
+    const keyNames = _.map(keys, 'name')
 
     // The first result of the regex will be the whole path
     keyNames.unshift('path')

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "co": "^4.1.0",
     "co-body": "^1.0.0",
     "co-defer": "^1.0.0",
-    "lodash": "^3.8.0",
+    "lodash": "^4.6.1",
     "mag-colored-output": "^1.0.0",
     "mag-format-message": "^0.1.1",
     "path-to-regexp": "^1.2.0",


### PR DESCRIPTION
Breaking changes:
https://github.com/lodash/lodash/wiki/Changelog#compatibility-warnings

There was a bug in lodash@3 when merging objects with Buffer properties
Fixed in v4:
https://github.com/lodash/lodash/commit/4a4e54479a6eecd916a0e39d400c54bcbba51c31