### PR TITLE
Comply with JCS by Base64URL-encoding keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/interledger/five-bells-shared",
   "dependencies": {
+    "base64url": "^1.0.6",
     "bcrypt": "^0.8.5",
     "canonical-json": "0.0.4",
     "co": "^4.1.0",

--- a/schemas/PublicKeyRSA.json
+++ b/schemas/PublicKeyRSA.json
@@ -15,10 +15,7 @@
     },
     "e": {
       "description": "RSA exponent.",
-      "oneOf": [
-        { "$ref": "Base64.json" },
-        { "$ref": "Base64URL.json" }
-      ]
+      "$ref": "Base64URL.json"
     },
     "required": ["type", "n", "e"],
     "additionalProperties": false

--- a/test/data/signData.json
+++ b/test/data/signData.json
@@ -1,39 +1,83 @@
 {
   "sampleNotification": {
-    "id": "6821484d-6ca7-4157-b15b-388c49637111",
-    "subscription_id":
-    "c6345f6e-d3c9-440b-8aa0-f0077c0c40f4",
-    "transfer_id": "ba32d964-f143-4b67-b470-d258025288d4",
-    "retry_count": 1,
-    "retry_at": 1457645427712
+    "id": "http://localhost/transfers/155dff3f-4915-44df-a707-acc4b527bcbd",
+    "subscription": "c6345f6e-d3c9-440b-8aa0-f0077c0c40f4",
+    "event": "transfer.update",
+    "resource": {
+      "debits": [
+        {
+          "account": "http://localhost/accounts/alice",
+          "amount": "10",
+          "authorized": true
+        }
+      ],
+      "credits": [
+        {
+          "account": "http://localhost/accounts/bob",
+          "amount": "10"
+        }
+      ],
+      "ledger": "http://localhost",
+      "state": "executed"
+    }
   },
   "expectedSignedNotification": {
-    "id": "6821484d-6ca7-4157-b15b-388c49637111",
-    "subscription_id": "c6345f6e-d3c9-440b-8aa0-f0077c0c40f4",
-    "transfer_id": "ba32d964-f143-4b67-b470-d258025288d4",
-    "retry_count": 1,
-    "retry_at": 1457645427712,
+    "id": "http://localhost/transfers/155dff3f-4915-44df-a707-acc4b527bcbd",
+    "subscription": "c6345f6e-d3c9-440b-8aa0-f0077c0c40f4",
+    "event": "transfer.update",
+    "resource": {
+      "debits": [
+        {
+          "account": "http://localhost/accounts/alice",
+          "amount": "10",
+          "authorized": true
+        }
+      ],
+      "credits": [
+        {
+          "account": "http://localhost/accounts/bob",
+          "amount": "10"
+        }
+      ],
+      "ledger": "http://localhost",
+      "state": "executed"
+    },
     "signature": {
       "algorithm": "ES256",
       "publicKey": {
         "type": "EC",
         "curve": "P-256",
-        "x": "fe6c0b5f44f167591005775e2cdb25c9ee6e885f3ff16cce418ce8a67fa2f93e",
-        "y": "4a839e3c4289ccf6a6c341fb860da3fb5173e5ddd4137bf7f44e0271c29f147a"
+        "x": "ZmU2YzBiNWY0NGYxNjc1OTEwMDU3NzVlMmNkYjI1YzllZTZlODg1ZjNmZjE2Y2NlNDE4Y2U4YTY3ZmEyZjkzZQ",
+        "y": "NGE4MzllM2M0Mjg5Y2NmNmE2YzM0MWZiODYwZGEzZmI1MTczZTVkZGQ0MTM3YmY3ZjQ0ZTAyNzFjMjlmMTQ3YQ"
       }
     }
   },
   "expectedRSASignedNotification": {
-    "id": "6821484d-6ca7-4157-b15b-388c49637111",
-    "subscription_id": "c6345f6e-d3c9-440b-8aa0-f0077c0c40f4",
-    "transfer_id": "ba32d964-f143-4b67-b470-d258025288d4",
-    "retry_count": 1,
-    "retry_at": 1457645427712,
+    "id": "http://localhost/transfers/155dff3f-4915-44df-a707-acc4b527bcbd",
+    "subscription": "c6345f6e-d3c9-440b-8aa0-f0077c0c40f4",
+    "event": "transfer.update",
+    "resource": {
+      "debits": [
+        {
+          "account": "http://localhost/accounts/alice",
+          "amount": "10",
+          "authorized": true
+        }
+      ],
+      "credits": [
+        {
+          "account": "http://localhost/accounts/bob",
+          "amount": "10"
+        }
+      ],
+      "ledger": "http://localhost",
+      "state": "executed"
+    },
     "signature": {
       "algorithm": "PS256",
       "publicKey": {
         "type": "RSA",
-        "e": "NjU1Mzc=",
+        "e": "NjU1Mzc",
         "n": "Njc1NTkwOTcxMTE2NTEwMTIyODY4MzE0NjkwMzkxODI3NTAyMjQ4MzA1NzQ3NzA0NTkxNDg3MzA4MzI4MzQ3ODEzODgyNTgwMTIzMDU1NzE4OTM1MjAyMTY2Njk0OTIwODcxMDkzMzcwNjA2MDc5NTU3Mzg2ODg1MjI3MTY0MTE2NTkwMDYxNTkzMDU0NTQyMDgyMzU0Nzc5NjczMzExODExMzMwNzkwNjI0NTMxNjIxMjg2OTg0MTE3NDgwNzM3MzUwNzUwNjM4Mzg0MjYzNDMwMjczNDQ0OTIwNDgyODY5MDc2MTgzNDEwOTc1NTU2NDM4MzYxNTg4MTIyNzIxNzU0NzU2ODcwNDAyMTI3OTcxNzIxMTc2MjkxMTE2MzEwNzIxMzEyOTExMTgwNTMyNDE5ODE4NzM0NjYwNTE3MDc0MDIxNDE4Nzc3Mjc5NjcwNDkyNjc1NDA5NzU1NTk2MzUxOTAwOTAwMTA5NDMyMzAzNzg2NjExMTA3NTExNjk1NDU2MzUwNzI5NDQ5NTE4NzkxNTQ1NTAxMjkzNDcwNzExNzI3MzExNDgwMDY3Njk2MDQ3MDgwNDAwMzE5Njk2MzYxNjk3NTY0MTg2NzIxNDI3NDMwNDIyMDk3MzExNjgxNjQxNDkyNjM2Nzk1ODQxNDE5MTY5MjM1NzM1MTUzNDA2MDc1MDk1OTk3NTc2MDA4NDE3NTEyMjgzMjY5MTI3NDU1OTU4OTM3MTk5MDI1MDMxNTM4NTIyMzE5MTg5MTMyOTM3NDgyNzg2NzE3MzAxMDM0MjkyMDM2NTEzMzQ2NDU2OTE4MzcwOTk1NzQyMDM5NzAwOTkyNDM3NzY5OTM1NDQ2OTc1OTIxNDE1NjQyMTU2NzIxMzkzMTAwMjQyMDkxMTk1NTIyMjQ5ODc3NTk3NzY2MjE3NzE2MDc4MzgxNzY1MjYxMDIyNjY4NjEwNzE0NTY1MTk5ODkzODcxMTU0NDQ5NTQzMzk4NjQzNTA0Njc3NjIwNjEwOTY5ODkwNzE2MDk0MTM5NjcxOTQ1MjY2ODEzNzY1MTkyOTc4Mjc0NjcwMTk2Njc5NDM5MTM4MjgxMTk5MTc5Nzg5NjIzMzU5ODk0MTExOTEwOTAxNTYyMTg1NjE1ODcxMzQ5NjQzOTA5MjcwMDg3ODM0MzUxNTg5NTA3MjgxOTc5NzE4MzQxMzkxNzc0NjE0NzI1NzI3MjQ0ODQ0MDM0NTUyNzg2ODQxNzM3MDQ5NDc0ODU4NTY3OTAxOTY4NTcyMjcxMTY2NDk5OTgzNjI0MjkyODcwMjM5ODY0Njk4ODU0ODY3ODAyMzk5NTUxNTE3MDcyOTI0MDk1OTUzMjY4MzEzNzk4Nzg5MDEyODUzNjc4OTU5NjE1MTg1NTUxNzQwMTU0MzYxODc3OTM3NjkxMzg4MzU0MDc1Nzk0ODA4OTQxOTEwNzkxMDA3Njc2MzQzNTcyODUwNjY4NTM3MjU2NjU5MDU1Mzk2ODE5ODc0OTk0NDA2NzMzNzc0NTEwMjE0MzYyMDYxNjc0MDc4OTI2NTEzODYwOTczMjEzNTY2OTQ1MDYwNjk5MjEyNTg5Njk2Njg2NjA4NjMwODYxOTA3OTQ2NTUyNzQzNzM5OTUyMDkzNTQxMzUxNjcx"
       }
     }


### PR DESCRIPTION
@naoitoi please review when you have a minute.

I noticed in some cases the public keys for JCS were failing JSON validation because they were not in Base64URL format. I changed `jsonSigning.js` to return public keys as Base64URL-encoded strings, and also added schema validation for the signature. This required changing `signData.json`, so the format matches the schema. Finally, I removed the `Base64.json` format as a possible RSA exponent (since it should now be `Base64URL.json`