### PR TITLE
Fix: Optionally parse ed25519

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -169,10 +169,7 @@ function parseDatabaseConfig (prefix) {
   })
 }
 
-/**
- * Parse keypair configuration from the environment
- */
-function parseKeyConfig (prefix) {
+function parseED25519 (prefix) {
   const ed25519 = {
     secret: getEnv(prefix, 'ED25519_SECRET_KEY'),
     public: getEnv(prefix, 'ED25519_PUBLIC_KEY')
@@ -198,9 +195,16 @@ function parseKeyConfig (prefix) {
       tweetnacl.util.encodeBase64(keyPair.publicKey)
   }
 
-  return {
-    ed25519
-  }
+  return ed25519
+}
+
+/**
+ * Parse keypair configuration from the environment
+ */
+function parseKeyConfig (prefix, options) {
+  return removeUndefined({
+    ed25519: options.ed25519 !== false ? parseED25519(prefix) : undefined
+  })
 }
 
 function parseAuthConfig (prefix) {
@@ -268,6 +272,8 @@ configProto.getIn = function getIn (propertyList, defaultValue) {
  *   to uppercase with underscores or other formats as necessary.
  *
  * @param {Object} [localConfig]
+ * @param {Object} [options]
+ * @param {Boolean} [options.ed25519] - 'false' if config should not parse ed25519 keypair
  * @returns {Object} - Frozen Config
  *
  * @example
@@ -282,11 +288,13 @@ configProto.getIn = function getIn (propertyList, defaultValue) {
  *   => {bar: 'baz'}
  *
  */
-function loadConfig (prefix, localConfig) {
+function loadConfig (prefix, localConfig, options) {
+  const _options = options || {}
+
   validateEnvConfig(prefix)
   const server = parseServerConfig(prefix)
   const db = parseDatabaseConfig(prefix)
-  const keys = parseKeyConfig(prefix)
+  const keys = parseKeyConfig(prefix, _options)
   const auth = parseAuthConfig(prefix)
   const tls = parseTLSConfig(prefix)
 

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -290,6 +290,12 @@ describe('Config', () => {
       expect(_config.getIn(['keys', 'ed25519'])).to.include.keys('secret', 'public')
       expect(_config.getIn(['keys', 'ed25519', 'secret'])).to.equal(secret)
     })
+
+    it('options.ed25519 = false', () => {
+      process.env.UNIT_TEST_OVERRIDE = 'true'
+      const _config = Config.loadConfig('', {}, {ed25519: false})
+      expect(_config.get('keys.ed25519')).to.equal(undefined)
+    })
   })
 
   describe('parseDatabaseConfig', () => {


### PR DESCRIPTION
When NODE_ENV=production, loadConfig will try to parse ed25519 keys for
the Connector, which does not require this keypair

The change here is backwards compatible.