### PR TITLE
Create ci-publish npm task

### DIFF
--- a/bin/bump.sh
+++ b/bin/bump.sh
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
 
 # http://www.tldp.org/LDP/abs/html/options.html
-set -eo pipefail
+set -ex pipefail
 
 INCREMENT="$1"
-
-# Debugging
-# set -x
 
 # http://stackoverflow.com/questions/1593051/how-to-programmatically-determine-the-current-checked-out-git-branch
 checkOnMaster() {

--- a/bin/ci-publish.sh
+++ b/bin/ci-publish.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -ex pipefail
+
+npmPublish() {
+  npm publish
+}
+
+currentVersion() {
+  grep version <package.json | sed 's/[^0-9.]*\([0-9.]*\).*/\1/' | head -n 1
+}
+
+currentProject() {
+  npm ls --depth=-1 | head -1 | cut -f 1 -d " " | sed 's/@.*//'
+}
+
+checkVersion() {
+  local gitTag
+  gitTag=$(git describe --tags)
+
+  if [ "v$(currentVersion)" != "$gitTag" ]; then
+    echo 'Current tag does not match package version. Skipping npm publish'
+    exit 0
+  fi
+}
+
+checkIsPublished() {
+  if [ -n "$(npm info "$(currentProject)"@"$(currentVersion)")" ]; then
+    echo 'Already published. Skipping npm publish'
+    exit 0
+  fi
+}
+
+checkVersion
+checkIsPublished
+npmPublish

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "lint": "eslint .",
     "test": "istanbul test -- _mocha",
     "jsdoc": "jsdoc -R README.md -c jsdoc.json lib/* && cp -r docs docs-out",
-    "bump": "./bin/bump.sh"
+    "bump": "./bin/bump.sh",
+    "ci-publish": "./bin/ci-publish.sh"
   },
   "bin": {
-    "version-bump": "./bin/bump.sh"
+    "version-bump": "./bin/bump.sh",
+    "ci-publish": "./bin/ci-publish.sh"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prevents npm publish errors (only publish on bump commits)

TODO
- Update five-bells-ledger, five-bells-notary, and five-bells-connector