### PR TITLE
fix: correctly parse auth config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -216,8 +216,9 @@ function parseAuthConfig (prefix) {
 }
 
 function validateEnvConfig (prefix) {
+  const authConfig = parseAuthConfig(prefix)
   const secureOrClientCertEnabled = castBool(getEnv(prefix, 'USE_HTTPS')) ||
-    getEnv(prefix, 'AUTH_CLIENT_CERT_ENABLED')
+    authConfig.client_certificates_enabled
 
   const tls = parseTLSEnv(prefix)
   if (secureOrClientCertEnabled && (tls.key === undefined || tls.cert === undefined)) {


### PR DESCRIPTION
Example of error:

```

 LEDGER_DB_URI=sqlite:// LEDGER_USE_HTTPS=false LEDGER_AUTH_CLIENT_CERT_ENABLED=false npm start

> five-bells-ledger@11.0.0 start /Users/alan/Projects/five-bells-ledger
> node src/app.js

/Users/alan/Projects/five-bells-ledger/node_modules/five-bells-shared/lib/config.js:225
    throw new ServerError(
    ^

ServerError: Missing ledger_TLS_KEY or ledger_TLS_CERTIFICATE
    at validateEnvConfig (/Users/alan/Projects/five-bells-ledger/node_modules/five-bells-shared/lib/config.js:225:11)
```