### PR TITLE
Better debug out for additionalProperties errors

### DIFF
--- a/errors/invalid-body-error.js
+++ b/errors/invalid-body-error.js
@@ -11,7 +11,15 @@ class InvalidBodyError extends BaseError {
   debugPrint (log, validationError, indent) {
     indent = indent || ''
     log.debug(indent + '-- ' + validationError)
-    log.debug(indent + '   ' + validationError.schemaPath)
+
+    // For additionalProperties errors we want to show the name of the property
+    // that violated the constraint.
+    if (validationError.code === 303) {
+      log.debug(indent + '   ' + validationError.dataPath)
+    } else {
+      log.debug(indent + '   ' + validationError.schemaPath)
+    }
+
     if (validationError.subErrors) {
       validationError.subErrors.forEach((subError) => {
         this.debugPrint(log, subError, '  ' + indent)


### PR DESCRIPTION
Previously the debug output told you which `additionalProperties` clause was being violated, but not the name of the offending property. That information is contained in `dataPath`. So by printing `dataPath` in the case of an `additionalProperties` error, we get a bit better information about what's wrong.