### PR TITLE
Feat/st ilp packet

### DIFF
--- a/errors/invalid-body-error.js
+++ b/errors/invalid-body-error.js
@@ -11,7 +11,15 @@ class InvalidBodyError extends BaseError {
   debugPrint (log, validationError, indent) {
     indent = indent || ''
     log.debug(indent + '-- ' + validationError)
-    log.debug(indent + '   ' + validationError.schemaPath)
+
+    // For additionalProperties errors we want to show the name of the property
+    // that violated the constraint.
+    if (validationError.code === 303) {
+      log.debug(indent + '   ' + validationError.dataPath)
+    } else {
+      log.debug(indent + '   ' + validationError.schemaPath)
+    }
+
     if (validationError.subErrors) {
       validationError.subErrors.forEach((subError) => {
         this.debugPrint(log, subError, '  ' + indent)

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -1,8 +1,13 @@
 'use strict'
 
+const co = require('co')
 const fs = require('fs')
 const path = require('path')
+const parse = require('co-body')
 const ServerError = require('../errors/server-error')
+const InvalidBodyError = require('../errors/invalid-body-error')
+const InvalidUriParameterError =
+  require('../errors/invalid-uri-parameter-error')
 
 const tv4 = require('tv4')
 const formats = require('tv4-formats')
@@ -77,6 +82,51 @@ class Validator {
       result.schema = schema
       return result
     }
+  }
+
+  /**
+   * Validate path parameter.
+   *
+   * @param {String} paramId Name of URL parameter.
+   * @param {String} paramValue Value of URL parameter.
+   * @param {String} schema Name of JSON schema.
+   *
+   * @returns {void}
+   */
+  validateUriParameter (paramId, paramValue, schema) {
+    const validationResult = this.tv4.validateMultiple(paramValue, schema + '.json')
+    if (!validationResult.valid) {
+      throw new InvalidUriParameterError(paramId + ' is not a valid ' + schema,
+        validationResult.errors)
+    }
+  }
+
+  /**
+   * Parse the request body JSON and optionally validate it against a schema.
+   *
+   * @param {Object} ctx Koa context.
+   * @param {String} schema Name of JSON schema.
+   *
+   * @returns {Promise.<Mixed>} Parsed JSON body
+   */
+  validateBody (ctx, schema) {
+    return co.wrap(this._validateBody).call(this, ctx, schema)
+  }
+
+  * _validateBody (ctx, schema) {
+    const json = yield parse(ctx)
+
+    if (schema) {
+      const validationResult = this.tv4.validateMultiple(json, schema + '.json')
+      if (!validationResult.valid) {
+        throw new InvalidBodyError('JSON request body is not a valid ' + schema,
+          validationResult.errors)
+      }
+      // TODO Might be good to do this for safety:
+      // return validationResult.cleanInstance
+    }
+
+    return json
   }
 }
 

--- a/schemas/IlpHeader.json
+++ b/schemas/IlpHeader.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "IlpHeader",
+  "description": "Header denoting the packet's final destination",
+  "type": "object",
+  "properties": {
+    "ledger": {
+      "description": "The ledger where the transfer will take place",
+      "$ref": "Iri.json"
+    },
+    "account": {
+      "description": "Account holding the funds",
+      "$ref": "Iri.json"
+    },
+    "amount": {
+      "description": "Amount as decimal",
+      "$ref": "Amount.json"
+    },
+    "data": {
+      "description": "User-specified memo, will be the memo of the final transfer",
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
In order to support different types of ledgers, the information that travels with the transfer should be ledger-agnostic. We've identified the minimum set of fields necessary to get the payment to its destination: `destinationAccount` and `destinationAmount`, called the ILP packet or ILP header.

This PR changes the format of the transfer memos to include the ILP header instead of the destination_transfer object as before.

Related PRs:

interledger/five-bells-connector#160
interledger/five-bells-notary#65
interledger/five-bells-sender#72