### PR TITLE
feat: add credit.{rejected,rejection_message}

### DIFF
--- a/schemas/Base64.json
+++ b/schemas/Base64.json
@@ -3,5 +3,5 @@
   "title": "Base64",
   "description": "Base64 string",
   "type": "string",
-  "pattern": "^(?:[A-Za-z0-9+\/]{4}\\n?)*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)$"
+  "pattern": "^(?:[A-Za-z0-9+\/]{4}\\n?)*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$"
 }

--- a/schemas/FundsTemplate.json
+++ b/schemas/FundsTemplate.json
@@ -26,6 +26,14 @@
     "authorized": {
       "description": "Indicates whether the debits or credits have been authorized by the required account holder",
       "type": "boolean"
+    },
+    "rejected": {
+      "description": "Indicates whether the credit has been rejected by the required account holder",
+      "type": "boolean"
+    },
+    "rejection_message": {
+      "description": "The reason the credit was rejected",
+      "$ref": "Base64.json"
     }
   },
   "required": ["account", "amount"],


### PR DESCRIPTION
Also fixes the `Base64` schema.

```
> (new RegExp("^(?:[A-Za-z0-9+\/]{4}\\n?)*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)$")).test( Buffer.from('abc').toString('base64') )
false
```